### PR TITLE
Add A/B test demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # gpt-protos
+
+Este repositorio contiene un ejemplo sencillo de prueba A/B con una tarjeta desplegable.
+
+Abre `index.html` en tu navegador para ver la demostración. Al recargar la página,
+se seleccionará aleatoriamente la variante A o B y se mantendrá durante la sesión
+del navegador. Haz clic en la tarjeta para desplegarla y observar la animación con
+`ease-out` (variante A) o con `ease-in-out` (variante B).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>A/B Test Card</title>
+<style>
+body {
+  font-family: Arial, sans-serif;
+  text-align: center;
+  margin-top: 40px;
+}
+.card {
+  width: 300px;
+  margin: 20px auto;
+  border: 1px solid #ccc;
+  overflow: hidden;
+  height: 50px;
+  transition: height 0.4s;
+}
+.card-content {
+  padding: 10px;
+}
+.card.expanded {
+  height: 150px;
+}
+/* Timing variants */
+.ease-out {
+  transition-timing-function: ease-out;
+}
+.ease-in-out {
+  transition-timing-function: ease-in-out;
+}
+</style>
+</head>
+<body>
+<h1 id="variant-title"></h1>
+<div id="card" class="card">
+  <div class="card-content">
+    <h2>Card Title</h2>
+    <p>Este es un ejemplo de contenido dentro de la tarjeta.</p>
+  </div>
+</div>
+<script>
+(function() {
+  var card = document.getElementById('card');
+  var title = document.getElementById('variant-title');
+
+  // Persist variant across reloads during the session
+  var variant = sessionStorage.getItem('ab_variant');
+  if (!variant) {
+    variant = Math.random() < 0.5 ? 'A' : 'B';
+    sessionStorage.setItem('ab_variant', variant);
+  }
+
+  // Apply variant specific timing function
+  if (variant === 'A') {
+    card.classList.add('ease-out');
+  } else {
+    card.classList.add('ease-in-out');
+  }
+  title.textContent = 'Variant ' + variant;
+
+  card.addEventListener('click', function() {
+    card.classList.toggle('expanded');
+  });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create collapsible card example that randomly uses ease-out or ease-in-out timing
- update README with instructions

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846fa2660e48326a0a81581add45f5b